### PR TITLE
chore(release): prepare v1.4.0 metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,12 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
+- No unreleased changes yet.
+
+---
+
+## [1.4.0] - 2026-03-18
+
 ### Added
 
 - `drift init`: project scaffolding command for `drift.config.ts`, optional CI workflow, and baseline generation.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@eduardbar/drift",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@eduardbar/drift",
-      "version": "1.3.0",
+      "version": "1.4.0",
       "license": "MIT",
       "dependencies": {
         "commander": "^14.0.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eduardbar/drift",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "description": "AI Code Audit CLI for merge trust in AI-assisted PRs",
   "type": "module",
   "main": "dist/index.js",


### PR DESCRIPTION
## Summary
- bump package metadata from 1.3.0 to 1.4.0 in package.json and package-lock.json
- finalize changelog by moving current unreleased notes into a dated 1.4.0 entry
- leave an empty Unreleased section for follow-up changes

## Why
This keeps release metadata consistent before cutting the next npm publish and GitHub release artifacts.