### PR TITLE
fix(ci): scope vscode publish workflow to extension tags

### DIFF
--- a/.github/workflows/publish-vscode.yml
+++ b/.github/workflows/publish-vscode.yml
@@ -3,8 +3,6 @@ name: Publish VS Code Extension
 on:
   release:
     types: [published]
-    tags:
-      - 'vscode-v*'
   workflow_dispatch:
     inputs:
       version:
@@ -17,6 +15,7 @@ permissions:
 
 jobs:
   publish:
+    if: ${{ github.event_name == 'workflow_dispatch' || startsWith(github.ref, 'refs/tags/vscode-v') }}
     runs-on: ubuntu-latest
     defaults:
       run:
@@ -36,7 +35,6 @@ jobs:
           cache-dependency-path: packages/vscode-drift/package-lock.json
 
       - name: Verify version matches tag
-        if: github.event_name == 'release'
         run: |
           if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
             TAG_VERSION="${{ inputs.version }}"


### PR DESCRIPTION
## Summary
- remove ineffective release tag filter under release trigger
- gate the VS Code publish job to run only for vscode-v* tags or manual dispatch
- keep version verification active for both release and workflow_dispatch paths

## Why
Core drift releases use vX.Y.Z tags and should not fail the VS Code extension workflow, which expects vscode-vX.Y.Z tags.