### PR TITLE
refactor(guard): split baseline and metrics helpers

### DIFF
--- a/src/guard-baseline.ts
+++ b/src/guard-baseline.ts
@@ -1,0 +1,74 @@
+import { existsSync, readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+import type { GuardBaseline, IssueSeverity } from './guard-types.js'
+
+export interface NormalizedBaseline {
+  score?: number
+  totalIssues?: number
+  bySeverity: Partial<Record<IssueSeverity, number>>
+}
+
+function parseNumber(value: unknown): number | undefined {
+  return typeof value === 'number' && !Number.isNaN(value) ? value : undefined
+}
+
+function firstDefinedNumber(values: unknown[]): number | undefined {
+  for (const value of values) {
+    const parsed = parseNumber(value)
+    if (parsed !== undefined) {
+      return parsed
+    }
+  }
+
+  return undefined
+}
+
+function normalizeSeverity(baseline: GuardBaseline, severity: IssueSeverity): number | undefined {
+  const summaryBySeverity = baseline.summary?.[`${severity}s` as 'errors' | 'warnings' | 'infos']
+
+  return firstDefinedNumber([
+    baseline.bySeverity?.[severity],
+    severity === 'error' ? baseline.errors : undefined,
+    severity === 'warning' ? baseline.warnings : undefined,
+    severity === 'info' ? baseline.infos : undefined,
+    summaryBySeverity,
+  ])
+}
+
+function hasAnchor(baseline: NormalizedBaseline): boolean {
+  if (baseline.score !== undefined || baseline.totalIssues !== undefined) {
+    return true
+  }
+
+  const severities: IssueSeverity[] = ['error', 'warning', 'info']
+  return severities.some((severity) => baseline.bySeverity[severity] !== undefined)
+}
+
+export function normalizeBaseline(baseline: GuardBaseline): NormalizedBaseline {
+  const normalized: NormalizedBaseline = {
+    score: parseNumber(baseline.score),
+    totalIssues: parseNumber(baseline.totalIssues),
+    bySeverity: {
+      error: normalizeSeverity(baseline, 'error'),
+      warning: normalizeSeverity(baseline, 'warning'),
+      info: normalizeSeverity(baseline, 'info'),
+    },
+  }
+
+  if (!hasAnchor(normalized)) {
+    throw new Error('Invalid guard baseline: expected score, totalIssues, or severity counters (error/warning/info).')
+  }
+
+  return normalized
+}
+
+export function readBaselineFromFile(projectPath: string, baselinePath?: string): { baseline: NormalizedBaseline; path: string } | undefined {
+  const resolvedBaselinePath = resolve(projectPath, baselinePath ?? 'drift-baseline.json')
+  if (!existsSync(resolvedBaselinePath)) return undefined
+
+  const raw = JSON.parse(readFileSync(resolvedBaselinePath, 'utf8')) as GuardBaseline
+  return {
+    baseline: normalizeBaseline(raw),
+    path: resolvedBaselinePath,
+  }
+}

--- a/src/guard-metrics.ts
+++ b/src/guard-metrics.ts
@@ -1,0 +1,52 @@
+import type { DriftDiff, DriftIssue, DriftReport } from './types.js'
+import type { GuardMetrics, IssueSeverity } from './guard-types.js'
+import type { NormalizedBaseline } from './guard-baseline.js'
+
+function createSeverityDelta(): Record<IssueSeverity, number> {
+  return {
+    error: 0,
+    warning: 0,
+    info: 0,
+  }
+}
+
+function applySeverityDelta(
+  delta: Record<IssueSeverity, number>,
+  issues: DriftIssue[],
+  direction: 1 | -1,
+): void {
+  for (const issue of issues) {
+    delta[issue.severity] += direction
+  }
+}
+
+function countSeverityDeltaFromDiff(diff: DriftDiff): Record<IssueSeverity, number> {
+  const severityDelta = createSeverityDelta()
+
+  for (const file of diff.files) {
+    applySeverityDelta(severityDelta, file.newIssues, 1)
+    applySeverityDelta(severityDelta, file.resolvedIssues, -1)
+  }
+
+  return severityDelta
+}
+
+export function buildMetricsFromDiff(diff: DriftDiff): GuardMetrics {
+  return {
+    scoreDelta: diff.totalDelta,
+    totalIssuesDelta: diff.newIssuesCount - diff.resolvedIssuesCount,
+    severityDelta: countSeverityDeltaFromDiff(diff),
+  }
+}
+
+export function buildMetricsFromBaseline(current: DriftReport, baseline: NormalizedBaseline): GuardMetrics {
+  return {
+    scoreDelta: current.totalScore - (baseline.score ?? current.totalScore),
+    totalIssuesDelta: current.totalIssues - (baseline.totalIssues ?? current.totalIssues),
+    severityDelta: {
+      error: current.summary.errors - (baseline.bySeverity.error ?? current.summary.errors),
+      warning: current.summary.warnings - (baseline.bySeverity.warning ?? current.summary.warnings),
+      info: current.summary.infos - (baseline.bySeverity.info ?? current.summary.infos),
+    },
+  }
+}

--- a/src/guard.ts
+++ b/src/guard.ts
@@ -1,13 +1,13 @@
-import { existsSync, readFileSync } from 'node:fs'
 import { relative, resolve } from 'node:path'
 import { analyzeProject } from './analyzer.js'
 import { loadConfig } from './config.js'
 import { computeDiff } from './diff.js'
 import { cleanupTempDir, extractFilesAtRef } from './git.js'
+import { normalizeBaseline, readBaselineFromFile } from './guard-baseline.js'
+import { buildMetricsFromBaseline, buildMetricsFromDiff } from './guard-metrics.js'
 import { buildReport } from './reporter.js'
-import type { DriftDiff, DriftReport } from './types.js'
+import type { DriftReport } from './types.js'
 import type {
-  GuardBaseline,
   GuardCheck,
   GuardEvaluation,
   GuardMetrics,
@@ -16,12 +16,7 @@ import type {
   GuardThresholds,
   IssueSeverity,
 } from './guard-types.js'
-
-interface NormalizedBaseline {
-  score?: number
-  totalIssues?: number
-  bySeverity: Partial<Record<IssueSeverity, number>>
-}
+import type { NormalizedBaseline } from './guard-baseline.js'
 
 interface GuardEvalInput {
   metrics: GuardMetrics
@@ -56,49 +51,6 @@ interface BaselineGuardResultInput {
   baselinePath?: string
 }
 
-function parseNumber(value: unknown): number | undefined {
-  return typeof value === 'number' && !Number.isNaN(value) ? value : undefined
-}
-
-function normalizeBaseline(baseline: GuardBaseline): NormalizedBaseline {
-  const bySeverityFromRoot = baseline.bySeverity
-  const bySeverity = {
-    error: parseNumber(bySeverityFromRoot?.error) ?? parseNumber(baseline.errors) ?? parseNumber(baseline.summary?.errors),
-    warning: parseNumber(bySeverityFromRoot?.warning) ?? parseNumber(baseline.warnings) ?? parseNumber(baseline.summary?.warnings),
-    info: parseNumber(bySeverityFromRoot?.info) ?? parseNumber(baseline.infos) ?? parseNumber(baseline.summary?.infos),
-  }
-
-  const normalized: NormalizedBaseline = {
-    score: parseNumber(baseline.score),
-    totalIssues: parseNumber(baseline.totalIssues),
-    bySeverity,
-  }
-
-  const hasAnyAnchor =
-    normalized.score !== undefined ||
-    normalized.totalIssues !== undefined ||
-    normalized.bySeverity.error !== undefined ||
-    normalized.bySeverity.warning !== undefined ||
-    normalized.bySeverity.info !== undefined
-
-  if (!hasAnyAnchor) {
-    throw new Error('Invalid guard baseline: expected score, totalIssues, or severity counters (error/warning/info).')
-  }
-
-  return normalized
-}
-
-function readBaselineFromFile(projectPath: string, baselinePath?: string): { baseline: NormalizedBaseline; path: string } | undefined {
-  const resolvedBaselinePath = resolve(projectPath, baselinePath ?? 'drift-baseline.json')
-  if (!existsSync(resolvedBaselinePath)) return undefined
-
-  const raw = JSON.parse(readFileSync(resolvedBaselinePath, 'utf8')) as GuardBaseline
-  return {
-    baseline: normalizeBaseline(raw),
-    path: resolvedBaselinePath,
-  }
-}
-
 function remapBaseReportPaths(baseReport: DriftReport, tempDir: string, projectPath: string): DriftReport {
   return {
     ...baseReport,
@@ -109,44 +61,6 @@ function remapBaseReportPaths(baseReport: DriftReport, tempDir: string, projectP
   }
 }
 
-function countSeverityDeltaFromDiff(diff: DriftDiff): Record<IssueSeverity, number> {
-  const severityDelta: Record<IssueSeverity, number> = {
-    error: 0,
-    warning: 0,
-    info: 0,
-  }
-
-  for (const file of diff.files) {
-    for (const issue of file.newIssues) {
-      severityDelta[issue.severity] += 1
-    }
-    for (const issue of file.resolvedIssues) {
-      severityDelta[issue.severity] -= 1
-    }
-  }
-
-  return severityDelta
-}
-
-function buildMetricsFromDiff(diff: DriftDiff): GuardMetrics {
-  return {
-    scoreDelta: diff.totalDelta,
-    totalIssuesDelta: diff.newIssuesCount - diff.resolvedIssuesCount,
-    severityDelta: countSeverityDeltaFromDiff(diff),
-  }
-}
-
-function buildMetricsFromBaseline(current: DriftReport, baseline: NormalizedBaseline): GuardMetrics {
-  return {
-    scoreDelta: current.totalScore - (baseline.score ?? current.totalScore),
-    totalIssuesDelta: current.totalIssues - (baseline.totalIssues ?? current.totalIssues),
-    severityDelta: {
-      error: current.summary.errors - (baseline.bySeverity.error ?? current.summary.errors),
-      warning: current.summary.warnings - (baseline.bySeverity.warning ?? current.summary.warnings),
-      info: current.summary.infos - (baseline.bySeverity.info ?? current.summary.infos),
-    },
-  }
-}
 
 interface GuardCheckInput {
   id: string


### PR DESCRIPTION
## Summary
- Split guard baseline normalization into src/guard-baseline.ts.
- Split guard metric delta builders into src/guard-metrics.ts.
- Kept guard behavior intact while reducing structural hotspots in src/guard.ts.

## Validation
- drift scan: totalScore 0, totalIssues 0
- tests: tests/phase1-init-doctor-guard.test.ts pass